### PR TITLE
Basic testing framework for EditTrack

### DIFF
--- a/tests/data/RefSeq_2.js
+++ b/tests/data/RefSeq_2.js
@@ -1,0 +1,7 @@
+define([],
+    function() {
+        var str=" TCATCCTCGTCTTTCTTTTTATTGTACTATTAATAGTGCTGTTGA";
+        // TCA TCC TCG TCT TTC TTT TTA TTG TAC TAT TAA TAG TGC TGT TGA
+        // S   S   S   S   F   F   L   L   Y   Y   *   *   C   C   *
+        return str;
+});

--- a/tests/data/tracks.js
+++ b/tests/data/tracks.js
@@ -1,0 +1,21 @@
+define([],
+        function () {
+
+    // NOTE: this is stub object only for testing purpose
+    var track = {
+    "key": "MAKER",
+    "label": "maker",
+    "config": {
+        "style": {
+            "className": "transcript",
+            "label": "name,id",
+            "subfeatureClasses": {
+                "CDS": "CDS",
+                "exon": "exon",
+                "five_prime_UTR": "five_prime_UTR",
+                "three_prime_UTR": "three_prime_UTR"
+            }
+        },
+    },
+};
+  return track; });

--- a/tests/data/transcripts/cds_1.js
+++ b/tests/data/transcripts/cds_1.js
@@ -1,0 +1,40 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    // This transcript is corresponding to RefSeq_2
+    // which is located in file data/RefSeq_2.js
+    var feature = {
+    "data": {
+    "seq_id": "testRefSeq2",
+        "end": 24,
+        "start": 1,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 24,
+                    "start": 1,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 24,
+                    "start": 1,
+                    "strand": 1,
+                    "type": "CDS"
+                }
+            },
+        ],
+        "type": "transcript"
+    },
+    "normalized": true,
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/input_1.js
+++ b/tests/data/transcripts/input_1.js
@@ -1,0 +1,97 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    var feature = {
+    "_uniqueID": "SimpleFeature_2",
+    "data": {
+        "end": 21389,
+        "name": "Si_estOR100817isotig20471",
+        "seq_id": "Si_gnF.scaffold02797",
+        "start": 16946,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "_uniqueID": "SimpleFeature_2_3",
+                "data": {
+                    "end": 17116,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 16946,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_317",
+                "data": {
+                    "end": 17116,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 17116,
+                    "strand": 1,
+                    "type": "non_canonical_splice_site"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_318",
+                "data": {
+                    "end": 19075,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19075,
+                    "strand": 1,
+                    "type": "non_canonical_splice_site"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_4",
+                "data": {
+                    "end": 19197,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19075,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_5",
+                "data": {
+                    "end": 20446,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 20258,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_6",
+                "data": {
+                    "end": 21106,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 21002,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_7",
+                "data": {
+                    "end": 21389,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 21298,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            }
+        ],
+        "type": "transcript"
+    },
+    "normalized": true
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/input_2.js
+++ b/tests/data/transcripts/input_2.js
@@ -1,0 +1,74 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    var feature = {
+    "data": {
+        "end": 19977,
+        "seq_id": "Si_gnF.scaffold02797",
+        "start": 18796,
+        "strand": -1,
+        "subfeatures": [
+            {
+                "data": {
+                    "end": 18869,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 18796,
+                    "strand": -1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+                    "end": 18869,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 18796,
+                    "strand": -1,
+                    "type": "CDS"
+                }
+            },
+            {
+                "data": {
+                    "end": 19210,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19075,
+                    "strand": -1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+                    "end": 19210,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19075,
+                    "strand": -1,
+                    "type": "CDS"
+                }
+            },
+            {
+                "data": {
+                    "end": 19977,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19819,
+                    "strand": -1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+                    "end": 19977,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19819,
+                    "strand": -1,
+                    "type": "CDS"
+                }
+            }
+        ],
+        "type": "transcript"
+    },
+    "normalized": true,
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/input_3.js
+++ b/tests/data/transcripts/input_3.js
@@ -1,0 +1,40 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    // This transcript is corresponding to RefSeq_2
+    // which is located in file data/RefSeq_2.js
+    var feature = {
+    "data": {
+    "seq_id": "testRefSeq2",
+        "end": 46,
+        "start": 1,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 46,
+                    "start": 1,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 46,
+                    "start": 1,
+                    "strand": 1,
+                    "type": "CDS"
+                }
+            },
+        ],
+        "type": "transcript"
+    },
+    "normalized": true,
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/input_4.js
+++ b/tests/data/transcripts/input_4.js
@@ -1,0 +1,40 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    // This transcript is corresponding to RefSeq_2
+    // which is located in file data/RefSeq_2.js
+    var feature = {
+    "data": {
+    "seq_id": "testRefSeq2",
+        "end": 24,
+        "start": 4,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 24,
+                    "start": 4,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 24,
+                    "start": 4,
+                    "strand": 1,
+                    "type": "CDS"
+                }
+            },
+        ],
+        "type": "transcript"
+    },
+    "normalized": true,
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/input_5.js
+++ b/tests/data/transcripts/input_5.js
@@ -1,0 +1,31 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    // This transcript is corresponding to RefSeq_2
+    // which is located in file data/RefSeq_2.js
+    var feature = {
+    "data": {
+    "seq_id": "testRefSeq2",
+        "end": 24,
+        "start": 1,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 24,
+                    "start": 1,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            }
+        ],
+        "type": "transcript"
+    },
+    "normalized": true,
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/input_6.js
+++ b/tests/data/transcripts/input_6.js
@@ -1,0 +1,31 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    // This transcript is corresponding to RefSeq_2
+    // which is located in file data/RefSeq_2.js
+    var feature = {
+    "data": {
+    "seq_id": "testRefSeq2",
+        "end": 44,
+        "start": 34,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 44,
+                    "start": 34,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            }
+        ],
+        "type": "transcript"
+    },
+    "normalized": true,
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/input_7.js
+++ b/tests/data/transcripts/input_7.js
@@ -1,0 +1,40 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    // This transcript is corresponding to RefSeq_2
+    // which is located in file data/RefSeq_2.js
+    var feature = {
+    "data": {
+    "seq_id": "testRefSeq2",
+        "end": 25,
+        "start": 1,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 13,
+                    "start": 1,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 25,
+                    "start": 16,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            }
+        ],
+        "type": "transcript"
+    },
+    "normalized": true,
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/input_8.js
+++ b/tests/data/transcripts/input_8.js
@@ -1,0 +1,31 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    // This transcript is corresponding to RefSeq_2
+    // which is located in file data/RefSeq_2.js
+    var feature = {
+    "data": {
+        "seq_id": "testRefSeq2",
+        "end": 13,
+        "start": 1,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "data": {
+                    "seq_id": "testRefSeq2",
+                    "end": 13,
+                    "start": 1,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            }
+        ],
+        "type": "transcript"
+    },
+    "normalized": true,
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/input_9.js
+++ b/tests/data/transcripts/input_9.js
@@ -1,0 +1,19 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    // This transcript is corresponding to RefSeq_2
+    // which is located in file data/RefSeq_2.js
+    var feature = {
+                "data": {
+                "seq_id": "testRefSeq2",
+                    "end": 13,
+                    "start": 1,
+                    "strand": 1,
+                    "type": "exon"
+                }
+                };
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/merge_1.js
+++ b/tests/data/transcripts/merge_1.js
@@ -1,0 +1,40 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    // This transcript is corresponding to RefSeq_2
+    // which is located in file data/RefSeq_2.js
+    var feature = {
+    "data": {
+    "seq_id": "testRefSeq2",
+        "end": 44,
+        "start": 1,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 24,
+                    "start": 1,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 44,
+                    "start": 34,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            }
+        ],
+        "type": "transcript"
+    },
+    "normalized": true,
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/normalize_1.js
+++ b/tests/data/transcripts/normalize_1.js
@@ -1,0 +1,29 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    var feature = {
+    "data": {
+    "seq_id": "testRefSeq2",
+        "end": 13,
+        "start": 1,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 13,
+                    "start": 1,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            }
+        ],
+        "type": "transcript"
+    },
+    "normalized": true,
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/orf_1.js
+++ b/tests/data/transcripts/orf_1.js
@@ -1,0 +1,39 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    // This transcript is corresponding to RefSeq_2
+    // which is located in file data/RefSeq_2.js
+    var feature = {
+    "data": {
+    "seq_id": "testRefSeq2",
+        "end": 46,
+        "start": 1,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 34,
+                    "start": 1,
+                    "strand": 1,
+                    "type": "CDS"
+                }
+            },
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 46,
+                    "start": 1,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            }
+        ],
+        "type": "transcript"
+    }
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/orf_2.js
+++ b/tests/data/transcripts/orf_2.js
@@ -1,0 +1,40 @@
+
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    // This transcript is corresponding to RefSeq_2
+    // which is located in file data/RefSeq_2.js
+    var feature = {
+    "data": {
+    "seq_id": "testRefSeq2",
+        "end": 24,
+        "start": 4,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 24,
+                    "start": 4,
+                    "strand": 1,
+                    "type": "CDS"
+                }
+            },
+            {
+                "data": {
+    "seq_id": "testRefSeq2",
+                    "end": 24,
+                    "start": 4,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            }
+        ],
+        "type": "transcript"
+    }
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/resize_1.js
+++ b/tests/data/transcripts/resize_1.js
@@ -1,0 +1,76 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+        function (SimpleFeature) {
+    var feature = {
+    "_uniqueID": "SimpleFeature_2",
+    "data": {
+        "end": 21389,
+        "name": "Si_estOR100817isotig20471",
+        "seq_id": "Si_gnF.scaffold02797",
+        "start": 16946,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "_uniqueID": "SimpleFeature_2_3",
+                "data": {
+                    "end": 17120,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 16946,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_4",
+                "data": {
+                    "end": 19197,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19075,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_5",
+                "data": {
+                    "end": 20446,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 20258,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_6",
+                "data": {
+                    "end": 21106,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 21002,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_7",
+                "data": {
+                    "end": 21389,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 21298,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            }
+        ],
+        "type": "transcript"
+    },
+    "normalized": true
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;});

--- a/tests/data/transcripts/resize_2.js
+++ b/tests/data/transcripts/resize_2.js
@@ -1,0 +1,66 @@
+
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+        function (SimpleFeature) {
+    var feature = {
+    "_uniqueID": "SimpleFeature_2",
+    "data": {
+        "end": 21389,
+        "name": "Si_estOR100817isotig20471",
+        "seq_id": "Si_gnF.scaffold02797",
+        "start": 16946,
+        "strand": 1,
+        "subfeatures": [
+            {
+                "_uniqueID": "SimpleFeature_2_4",
+                "data": {
+                    "end": 19197,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 16946,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_5",
+                "data": {
+                    "end": 20446,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 20258,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_6",
+                "data": {
+                    "end": 21106,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 21002,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            },
+            {
+                "_uniqueID": "SimpleFeature_2_7",
+                "data": {
+                    "end": 21389,
+                    "name": "Si_estOR100817isotig20471",
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 21298,
+                    "strand": 1,
+                    "type": "exon"
+                }
+            }
+        ],
+        "type": "transcript"
+    },
+    "normalized": true
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;});

--- a/tests/data/transcripts/resize_3.js
+++ b/tests/data/transcripts/resize_3.js
@@ -1,0 +1,74 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    var feature = {
+    "data": {
+        "end": 19977,
+        "seq_id": "Si_gnF.scaffold02797",
+        "start": 18796,
+        "strand": -1,
+        "subfeatures": [
+            {
+                "data": {
+                    "end": 18869,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 18796,
+                    "strand": -1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+                    "end": 18869,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 18796,
+                    "strand": -1,
+                    "type": "CDS"
+                }
+            },
+            {
+                "data": {
+                    "end": 19210 + 3,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19075,
+                    "strand": -1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+                    "end": 19210 + 3,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19075,
+                    "strand": -1,
+                    "type": "CDS"
+                }
+            },
+            {
+                "data": {
+                    "end": 19977,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19819,
+                    "strand": -1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+                    "end": 19977,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19819,
+                    "strand": -1,
+                    "type": "CDS"
+                }
+            }
+        ],
+        "type": "transcript"
+    },
+    "normalized": true,
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/resize_4.js
+++ b/tests/data/transcripts/resize_4.js
@@ -1,0 +1,56 @@
+define([
+        'JBrowse/Model/SimpleFeature'
+        ],
+function (SimpleFeature) {
+    var feature = {
+    "data": {
+        "end": 19977,
+        "seq_id": "Si_gnF.scaffold02797",
+        "start": 18796,
+        "strand": -1,
+        "subfeatures": [
+            {
+                "data": {
+                    "end": 19210,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 18796,
+                    "strand": -1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+                    "end": 19210,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19071, // verify that there is a stop codon at this location
+                    "strand": -1,
+                    "type": "CDS"
+                }
+            },
+            {
+                "data": {
+                    "end": 19977,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19819,
+                    "strand": -1,
+                    "type": "exon"
+                }
+            },
+            {
+                "data": {
+                    "end": 19977,
+                    "seq_id": "Si_gnF.scaffold02797",
+                    "start": 19819,
+                    "strand": -1,
+                    "type": "CDS"
+                }
+            }
+        ],
+        "type": "transcript"
+    },
+    "normalized": true,
+};
+
+var transcript = SimpleFeature.fromJSON(feature);
+return transcript;
+});

--- a/tests/data/transcripts/transcript_data.js
+++ b/tests/data/transcripts/transcript_data.js
@@ -1,0 +1,51 @@
+define([
+        './input_1',
+        './input_2',
+        './input_3',
+        './input_4',
+        './input_5',
+        './input_6',
+        './input_7',
+        './input_8',
+        './input_9',
+        './resize_1',
+        './resize_2',
+        './resize_3',
+        './resize_4',
+        './orf_1',
+        './orf_2',
+        './cds_1',
+        './merge_1',
+        './normalize_1'
+        ], function (
+            input_1,
+            input_2,
+            input_3,
+            input_4,
+            input_5,
+            input_6,
+            input_7,
+            input_8,
+            input_9,
+            resize_1,
+            resize_2,
+            resize_3,
+            resize_4,
+            orf_1,
+            orf_2,
+            cds_1,
+            merge_1,
+            normalize_1
+            ) {
+var transcript_data = {
+    "input": [input_1, input_2, input_3, input_4, input_5, input_6, input_7,
+                input_8],
+    "resize": [resize_1, resize_2, resize_3, resize_4],
+    "orf": [orf_1, orf_2],
+    "cds": [cds_1],
+    "merge": [merge_1],
+    "normalize": [normalize_1]
+
+};
+return transcript_data;
+});

--- a/tests/js/EditTrack.spec.js
+++ b/tests/js/EditTrack.spec.js
@@ -1,0 +1,191 @@
+define([
+        'underscore',
+        'jquery',
+        'JBrowse/Browser',
+        'JBrowse/Model/SimpleFeature',
+        '../tests/data/RefSeq_1',
+        '../tests/data/RefSeq_2',
+        '../tests/data/transcripts/transcript_data',
+        '../tests/data/tracks',
+        ], function (
+            _,
+            $,
+            Browser,
+            SimpleFeature,
+            refSeq,
+            refSeq_2,
+            transcript_data,
+            track
+            ) {
+
+describe( "Edit Track", function() {
+
+    var baseURL = '/data/jbrowse/Solenopsis_invicta/Si_gnF';
+    var jbrowse = new Browser({
+        containerID: 'genome',
+        baseUrl: baseURL,
+        include: [baseURL + '/trackList.json', '/data/jbrowse/edit-track.json'],
+        refSeqs: baseURL + '/seq/refSeqs.json'
+    });
+
+    var editTrack;
+    var sortAnnotations = function(annots) {
+
+        if (!_.isArray(annots)) return;
+
+        return annots.sort(function(annot1, annot2) {
+            var start1 = annot1.get("start");
+            var end1 = annot1.get("end");
+            var start2 = annot2.get("start");
+            var end2 = annot2.get("end");
+            var type1 = annot1.get("type");
+            var type2 = annot2.get("type");
+
+            if (start1 != start2)  { return start1 - start2; }
+            else if (end1 != end2) { return end1 - end2; }
+            else                   { if (type1 === type2) {
+                                       return 0;
+                                   }
+                                   else {
+                                       if(type1 < type2) {
+                                           return -1;
+                                       }
+                                       else {
+                                           return 1;
+                                       }
+                                   }
+                               }
+        });
+    };
+
+    /**
+     * Returns `true` if the given SimpleFeature objects are "equal" and false
+     * if they aren't.
+     * Two SimpleFeature A and B are to be considered equal if
+     * 1. If the type, start, end, strand and seq_id of A is same that of B.
+     * 2. If any of A or B contains subfeatures then the set of subfeatures of
+     *    A should be "equal" to the set of subfeatures of B.
+     **/
+    var compareFeatures = function(feature_a, feature_b) {
+        var a = feature_a.data;
+        var b = feature_b.data;
+
+        if (a.type === b.type
+                && a.seq_id === b.seq_id
+                && a.start === b.start
+                && a.end === b.end
+                && a.strand === b.strand) {
+            if (a.subfeatures !== undefined || b.subfeatures !== undefined) {
+                return _.every(_.zip(sortAnnotations(a.subfeatures),
+                            sortAnnotations(b.subfeatures)), function (sub_pair) {
+                                return compareFeatures(sub_pair[0], sub_pair[1]);
+                            });
+            }
+            return true;
+        }
+        return false;
+    };
+
+    beforeEach(function(done) {
+        setTimeout(function () {
+            editTrack = jbrowse.getEditTrack();
+            done();
+        }, 1000);
+    });
+
+    it( 'constructs', function() {
+        expect(editTrack).toBeTruthy();
+        expect(compareFeatures).toBeDefined();
+        expect(refSeq).toBeDefined();
+        expect(refSeq_2).toBeDefined();
+        expect(transcript_data).toBeDefined();
+        expect(track).toBeDefined();
+    });
+
+    it( 'tests comparison function', function() {
+        expect(compareFeatures(transcript_data["input"][0], transcript_data["input"][0])).toBe(true);
+    });
+
+    it('tests getWholeCDSCoordinates', function() {
+        expect(editTrack.getWholeCDSCoordinates(transcript_data.input[0])).toEqual([undefined, undefined]);
+        expect(editTrack.getWholeCDSCoordinates(transcript_data.input[1])).toEqual([19977, 18796]);
+    });
+
+    it('tests transcriptToCDNA', function() {
+        expect(editTrack.transcriptToCDNA(transcript_data.input[3], 4)).toEqual(0);
+    });
+
+    it('tests CDNAToTranscript', function() {
+        expect(editTrack.CDNAToTranscript(transcript_data.input[3], 0)).toEqual(4);
+    });
+
+    it('tests getCDNA', function() {
+        expect(editTrack.getCDNA(refSeq_2, transcript_data.input[2])).toEqual(refSeq_2.slice(1));
+    });
+
+    it('tests getCDS', function() {
+        expect(editTrack.getCDS(refSeq_2, transcript_data.input[2])).toEqual(refSeq_2.slice(1));
+    });
+
+
+    it ('test setORF', function() {
+        expect(compareFeatures(
+                editTrack.setORF(refSeq_2, transcript_data.input[2]),
+                transcript_data.orf[0])).toBe(true);
+
+        expect(compareFeatures(
+                editTrack.setORF(refSeq_2, transcript_data.input[3]),
+                transcript_data.orf[1])).toBe(true);
+    });
+
+    it ('tests setCDS', function() {
+        expect(compareFeatures(
+                editTrack.setCDS(transcript_data.input[4], 0, 24),
+                transcript_data.cds[0])).toBe(true);
+    });
+
+    it( 'tests resizeExon', function() {
+        exon = editTrack.filterExons(transcript_data["input"][0])[0];
+        var right = 17120;
+        var left = exon.get('start');
+        outTranscript = editTrack.resizeExon(refSeq, transcript_data["input"][0], exon, left, right);
+        expect(compareFeatures(transcript_data["resize"][0], outTranscript)).toBe(true);
+
+        exon = editTrack.filterExons(transcript_data["input"][1])[1];
+        var right = exon.get('end') + 3;
+        var left = exon.get('start');
+        outTranscript = editTrack.resizeExon(refSeq, transcript_data["input"][1], exon, left, right);
+        expect(compareFeatures(transcript_data["resize"][2], outTranscript)).toBe(true);
+    });
+
+    it( 'tests areOnSameStrand', function() {
+        expect(editTrack.areOnSameStrand([transcript_data.input[0], transcript_data.input[2]])).toBe(true);
+        expect(editTrack.areOnSameStrand([transcript_data.input[0], transcript_data.input[1]])).toBe(false);
+    });
+
+    it( 'tests mergeTranscripts', function() {
+        expect(compareFeatures(
+                editTrack.mergeTranscripts(refSeq_2,
+                    [transcript_data.input[7], transcript_data.input[7]]),
+                transcript_data.input[7])).toBe(true);
+
+        expect(compareFeatures(
+                editTrack.mergeTranscripts(refSeq_2,
+                    [transcript_data.input[6], transcript_data.input[7]]),
+                transcript_data.input[6])).toBe(true);
+
+            expect(compareFeatures(
+                    editTrack.mergeTranscripts(refSeq_2,
+                        [transcript_data.input[4], transcript_data.input[5]]),
+                    transcript_data.merge[0])).toBe(true);
+
+    });
+
+    it( 'tests normalizeFeature', function() {
+        exon = editTrack.filterExons(transcript_data.input[7])[0];
+        expect(compareFeatures(
+                editTrack.normalizeFeature(exon, track),
+                transcript_data.normalize[0])).toBe(true);
+    });
+});
+});

--- a/tests/js/index.html
+++ b/tests/js/index.html
@@ -14,5 +14,6 @@
   <script data-main="runner" src="../../www/lib/requirejs/require.js"></script>
 </head>
 <body>
+<div id="genome" style="display:none"></div>
 </body>
 </html>

--- a/tests/js/runner.js
+++ b/tests/js/runner.js
@@ -222,8 +222,7 @@ require(['jasmine/jasmine']
         }
 
         require([
-            'JBrowse/Browser',
-            "ExportGFF3.spec.js",
+            "JBrowse/Browser",
             "ExportGFF3.spec.js",
             "LazyArray.spec.js",
             "FeatureLayout.spec.js",
@@ -239,6 +238,7 @@ require(['jasmine/jasmine']
             "TabixIndexedFile.spec.js",
             "RESTStore.spec.js",
             "RegularizeRefSeqs.spec.js",
+            "EditTrack.spec.js",
             "GFF3.spec.js"
         ]
         , function () {

--- a/www/JBrowse/Store/SeqFeature/ScratchPad.js
+++ b/www/JBrowse/Store/SeqFeature/ScratchPad.js
@@ -57,27 +57,7 @@ define(['underscore',
         // retreived objects are different.
         _parseLocalStorage: function () {
             var localFeatures = JSON.parse(localStorage.getItem('features'));
-            // Directly constructing a transcript out of parsed JSON data
-            // results in a duplicated level of nesting inside array of
-            // SimpleFeature objects.
-            //
-            // To avoid that, we:
-            // * save the subfeatures array data from the parsed data,
-            // * generate the full transcript and delete the incorrect portion,
-            // * generate SimpleFeature objects from saved array and insert
-            //   them back into the transcript,
-            // * return the corrected transcript.
-            var localFeatures = _.map(localFeatures, function (feature) {
-                var subfeatures = feature.data.subfeatures;
-                delete feature.data.subfeatures;
-                var transcript = new SimpleFeature(feature);
-                subfeatures = _.map(subfeatures, function (f) {
-                    f.parent = transcript;
-                    return new SimpleFeature(f);
-                });
-                transcript.set('subfeatures', subfeatures);
-                return transcript;
-            });
+            localFeatures = _.map(localFeatures, SimpleFeature.fromJSON);
             return localFeatures;
         },
 
@@ -87,10 +67,7 @@ define(['underscore',
         // We avoid that by replacing _parent values using a custom
         // replacer function.
         _updateLocalStorage: function () {
-            var features = JSON.stringify(this.features, function (key, value) {
-                if (key === '_parent' && value) return;
-                return value;
-            });
+            var features = SimpleFeature.toJSON(this.features);
             localStorage.setItem('features', features);
         },
 


### PR DESCRIPTION
This PR:
* Adds comparison function to test the equality of two transcript
* Sets up testing data and adds to functions to import and export them.
* Sets up the basic infrastructure for testing `EditTrack`.
    * Creates an instance of `browser` for jasmine
    * Creates an instance of `EditTrack`. The `getEditTrack` function of `browser` works only after the `browser` is initialized hence it has to be put in the [beforeEach](http://jasmine.github.io/2.0/introduction.html#section-Setup_and_Teardown) function.
* Write basic tests for various functions of `editTrack`.